### PR TITLE
v0.15

### DIFF
--- a/block.pde
+++ b/block.pde
@@ -42,7 +42,7 @@ class block {
   void draw(int x,int y,int z,int faceToRender,PShape shape) {
     int[] c=boxCoords[faceToRender];
     for (int j=0; j<c.length; j+=3) {
-      shape.vertex((x+c[j]),(y+c[j+1]),(z+c[j+2]),c[j+coordsForMapping[faceToRender][0]]<<4,c[j+coordsForMapping[faceToRender][1]]<<4);
+      shape.vertex((x+c[j]),(y+c[j+1]),(z+c[j+2]),c[j+coordsForMapping[faceToRender][0]]*16,c[j+coordsForMapping[faceToRender][1]]*16);
     }
   }
 }

--- a/chunk.pde
+++ b/chunk.pde
@@ -14,6 +14,7 @@ class chunk {
   int px,py,chunkX,chunkY;
   PShape renderShape;
   chunkManager cm;
+  int[][][][] renderBlocks;
   boolean isLoaded=false,isRendered=false;
 
   chunk(chunkManager cm,block[] blocks,int chunkX,int chunkY) {
@@ -23,6 +24,7 @@ class chunk {
     this.chunkY=chunkY;
     this.px=chunkX*16;
     this.py=chunkY*16;
+    renderBlocks=new int[blocks.length][boxCoords.length][0][3];
   }
   
   chunk(chunkManager cm,block[] blocks,int chunkX,int chunkY,int px,int py) {
@@ -32,6 +34,7 @@ class chunk {
     this.chunkY=chunkY;
     this.px=px;
     this.py=py;
+    renderBlocks=new int[blocks.length][boxCoords.length][0][3];
   }
   
   void copyFrom(chunk c){
@@ -39,6 +42,8 @@ class chunk {
     this.py=c.py;
     this.blocksData=c.blocksData;
     this.renderShape=c.renderShape;
+    this.isRendered=c.isRendered;
+    this.renderBlocks=c.renderBlocks;
   }
   
   void moveTo(int x,int y){
@@ -46,7 +51,7 @@ class chunk {
     this.py+=y*16;
   }
   
-  void createRenderShape(int[][][][] renderBlocks){
+  void createRenderShape(){
     renderShape=createShape(GROUP);
     for(int blockId=0;blockId<blocks.length;blockId++) for(int faceId=0;faceId<boxCoords.length;faceId++){
       PShape cchunk=createShape();
@@ -94,13 +99,11 @@ class chunk {
     isLoaded=true;
   }
 
-  void renderShape(){
+  void computeFacesToRender(){
     isRendered=false;
-    int[][][][] renderBlocks=new int[blocks.length][boxCoords.length][0][3];
     for(int x=0; x<blocksData.length; x++) for (int y=0; y<blocksData[0].length; y++) for (int z=0; z<blocksData[0][0].length; z++) if(blocksData[x][y][z]!=0){
       int[] faces=shouldRender(x,y,z);
       for(int i=0;i<faces.length;i++) renderBlocks[blocksData[x][y][z]-1][faces[i]]=(int[][])append(renderBlocks[blocksData[x][y][z]-1][faces[i]],new int[]{x,y,z});
     }
-    createRenderShape(renderBlocks);
   }
 }

--- a/chunk.pde
+++ b/chunk.pde
@@ -7,17 +7,14 @@ int[][] order={
   new int[]{0,-1,0} //bottom
 };
 
-import java.util.concurrent.atomic.AtomicBoolean;
 
 class chunk {
   int[][][] blocksData=new int[16][256][16];
   block[] blocks;
-  chunkLoader cLoad;
-  Thread loadThread;
   int px,py,chunkX,chunkY;
   PShape renderShape;
   chunkManager cm;
-  AtomicBoolean isLoaded=new AtomicBoolean(false),isRendering=new AtomicBoolean(false),isRendered=new AtomicBoolean(false);
+  boolean isLoaded=false,isRendered=false;
 
   chunk(chunkManager cm,block[] blocks,int chunkX,int chunkY) {
     this.cm=cm;
@@ -26,8 +23,6 @@ class chunk {
     this.chunkY=chunkY;
     this.px=chunkX*16;
     this.py=chunkY*16;
-
-    cLoad=new chunkLoader(this);
   }
   
   chunk(chunkManager cm,block[] blocks,int chunkX,int chunkY,int px,int py) {
@@ -37,15 +32,12 @@ class chunk {
     this.chunkY=chunkY;
     this.px=px;
     this.py=py;
-
-    cLoad=new chunkLoader(this);
   }
   
   void copyFrom(chunk c){
     this.px=c.px;
     this.py=c.py;
     this.blocksData=c.blocksData;
-    this.loadThread=c.loadThread;
     this.renderShape=c.renderShape;
   }
   
@@ -58,7 +50,6 @@ class chunk {
     renderShape=createShape(GROUP);
     for(int blockId=0;blockId<blocks.length;blockId++) for(int faceId=0;faceId<boxCoords.length;faceId++){
       PShape cchunk=createShape();
-      cchunk.disableStyle();
       cchunk.setTexture(blocks[blockId].tex[faceId]);
       cchunk.beginShape(QUADS);
       for(int j=0;j<renderBlocks[blockId][faceId].length;j++){
@@ -69,6 +60,8 @@ class chunk {
       renderShape.addChild(cchunk);
     }
     renderShape.disableStyle();
+    renderShape.draw(g);
+    isRendered=true;
   }
 
   int[] shouldRender(int ox, int oy, int oz){
@@ -91,49 +84,23 @@ class chunk {
     return facesToRender;
   }
 
-  void startThread(){
-    isLoaded=new AtomicBoolean(false);
-    isRendering=new AtomicBoolean(false);
-    isRendered=new AtomicBoolean(false);
-    if(loadThread!=null&&loadThread.isAlive()){
-      println("!!Thread already running");
-      return;
-    }
-    loadThread=new Thread(cLoad);
-    loadThread.setPriority(1);
-    loadThread.start();
-  }
-
   void generate(){
+    isLoaded=false;
     for(int x=0; x<blocksData.length; x++) for (int z=0; z<blocksData[0][0].length; z++){
       float noise=(float)ImprovedNoise.noise((px+x)/100.0,(py+z)/100.0,0.0)+1;
       int hgt=floor(noise*(blocksData[0].length/10));
       for(int y=0;y<hgt;y++) blocksData[x][y][z]=1;
     }
-    isLoaded.set(true);
+    isLoaded=true;
   }
 
   void renderShape(){
-    isRendering.set(true);
+    isRendered=false;
     int[][][][] renderBlocks=new int[blocks.length][boxCoords.length][0][3];
     for(int x=0; x<blocksData.length; x++) for (int y=0; y<blocksData[0].length; y++) for (int z=0; z<blocksData[0][0].length; z++) if(blocksData[x][y][z]!=0){
       int[] faces=shouldRender(x,y,z);
       for(int i=0;i<faces.length;i++) renderBlocks[blocksData[x][y][z]-1][faces[i]]=(int[][])append(renderBlocks[blocksData[x][y][z]-1][faces[i]],new int[]{x,y,z});
     }
     createRenderShape(renderBlocks);
-    isRendered.set(true);
-  }
-}
-
-class chunkLoader implements Runnable{
-  chunk c;
-
-  chunkLoader(chunk c){
-    this.c=c;
-  }
-
-  void run(){
-    c.generate();
-    c.cm.chunkLoadingFinished(c);
   }
 }

--- a/chunk_manager.pde
+++ b/chunk_manager.pde
@@ -1,3 +1,5 @@
+import java.util.concurrent.ConcurrentLinkedQueue;
+
 class chunkManager{
   chunk[] chunk;
   block[] blocks;
@@ -5,12 +7,16 @@ class chunkManager{
   int[][] chunkCoords;
   int renderDist=3;
   int px,py;
-
+  chunkLoader load;
+  Thread loadThread;
+  
   chunkManager(block[] blocks,player p,int rd){
     this.blocks=blocks;
     this.p=p;
     px=0;
     py=0;
+    
+    load=new chunkLoader(this);
 
     renderDist=rd;
     int area=0;
@@ -21,15 +27,19 @@ class chunkManager{
     int ind=0;
     for(int x=-renderDist;x<renderDist;x++) for(int y=-renderDist;y<renderDist;y++) if(abs(x+0.5)<sqrt(1-sq((float)(y+0.5)/renderDist))*renderDist){
       chunkCoords[x+rd][y+rd]=ind;
+      load.addToQueue(ind);
       chunk[ind]=new chunk(this,blocks,x,y);
-      chunk[ind].startThread();
       ind++;
     }
     else chunkCoords[x+rd][y+rd]=-1;
+    
+    startChunkRender();
   }
 
   void renderShape(){
-    for(int i=0;i<chunk.length;i++) if(chunk[i]!=null&&chunk[i].isRendered.get()) shape(chunk[i].renderShape);
+    for(int i=0;i<chunk.length;i++){
+      if(chunk[i]!=null&&chunk[i].isRendered) shape(chunk[i].renderShape);
+    }
   }
 
   void updateChunk(){
@@ -82,17 +92,33 @@ class chunkManager{
         int ind=chunkToRender[i];
         chunk[ind]=new chunk(this,blocks,chunk[ind].chunkX,chunk[ind].chunkY,chunk[ind].px,chunk[ind].py);
         chunk[ind].moveTo(depX,depY);
-        chunk[ind].startThread();
+        load.addToQueue(ind);
       }
-      for(int i=0;i<chunk.length;i++) appendToFile(sketchPath("chunkPosTest"),chunk[i].px/16+":"+chunk[i].py/16+" : "+getChunkIndex(chunk[i].chunkX,chunk[i].chunkY));
+      startChunkRender();
+    }
+  }
+  
+  void startChunkRender(){
+    if(loadThread==null||!loadThread.isAlive()){
+      loadThread=new Thread(load);
+      loadThread.start();
+    }
+  }
+  
+  void generateAndRender(){
+    while(!load.chunksToRender.isEmpty()){
+      int ind=load.chunksToRender.poll();
+      chunk[ind].generate();
+      chunkLoadingFinished(chunk[ind]);
     }
   }
 
   void chunkLoadingFinished(chunk c){
     int ind=getChunkIndex(c.chunkX,c.chunkY);
-    for(int x=-1;x<=1;x++) for(int y=-1;y<=1;y++){
-      int ax=x+c.chunkX;
-      int ay=y+c.chunkY;
+    tryToRender(c.chunkX,c.chunkY);
+    for(int i=0;i<chunkAround.length;i++){
+      int ax=chunkAround[i][0]+c.chunkX;
+      int ay=chunkAround[i][1]+c.chunkY;
 
       if(getChunkIndex(ax,ay)!=-1) tryToRender(ax,ay);
     }
@@ -107,16 +133,15 @@ class chunkManager{
   void tryToRender(int cx,int cy){
     boolean adjChunkLoaded=true;
     int chunkIndex=getChunkIndex(cx,cy);
-    if(chunk[chunkIndex]==null||!chunk[chunkIndex].isLoaded.get()||chunk[chunkIndex].isRendered.get()||chunk[chunkIndex].isRendering.get()) return;
+    if(chunk[chunkIndex]==null||!chunk[chunkIndex].isLoaded||chunk[chunkIndex].isRendered) return;
     for(int i=0;i<chunkAround.length;i++){
       int cInd=getChunkIndex(chunkAround[i][0]+cx,chunkAround[i][1]+cy);
-      if(cInd!=-1&&chunk[cInd]!=null&&!chunk[cInd].isLoaded.get()){
+      if(cInd!=-1&&chunk[cInd]!=null&&!chunk[cInd].isLoaded){
         adjChunkLoaded=false;
         break;
       }
     }
     if(adjChunkLoaded){
-      //println(getChunkIndex(cx,cy));
       chunk[chunkIndex].renderShape();
     }
   }
@@ -133,7 +158,31 @@ class chunkManager{
 
     if(angDif(ang,p.lr)<p.fov/2) return true;
     return false;
-    //return true;
-    //return (ang>angMin&&ang<angMax);
+  }
+}
+
+class chunkLoader implements Runnable{
+  chunkManager cm;
+  ConcurrentLinkedQueue<Integer> chunksToRender=new ConcurrentLinkedQueue<Integer>();
+  
+  chunkLoader(chunkManager cm){
+    this.cm=cm;
+  }
+  
+  void setQueue(int[] chunks){
+    chunksToRender=new ConcurrentLinkedQueue<Integer>();
+    for(int i=0;i<chunks.length;i++) chunksToRender.add(chunks[i]);
+  }
+  
+  void addToQueue(int[] chunks){
+    for(int i=0;i<chunks.length;i++) chunksToRender.add(chunks[i]);
+  }
+  
+  void addToQueue(int chunk){
+    chunksToRender.add(chunk);
+  }
+  
+  void run(){
+    cm.generateAndRender();
   }
 }

--- a/minecrap.pde
+++ b/minecrap.pde
@@ -1,12 +1,5 @@
 /*
-- changement du sens des coordonnées en y pour etre en accord avec la camera (y positif vers le haut)
-- le tableau renderBlock est maintenant créer seulement lors de la création du shape pour gagner un peu de ram (on devrat peut etre le rechanger plus tard)
-- génération de monde infini :
-  - ajout de la fonction copyFrom et d'un nouveau constructeur dans la class chunk pour permettre de bouger les chunks qui sont affichés
-  - réinitialisation des variables isLoaded, isrendering et isRendered lors du lancement d'un thread pour permettre de relancer un thread d un chunk déjà loadé
-  - suppression du translate dans le renderShape, les chunks sont generés avec les bonnes coords
-  - amelioration de la fonction updateChunk dans la class chunkManager pour shifter les chunks et génerer les nouveaux
-- leger changement du mouvement de la camera avec la souris pour eviter le bug qui fait voir le ciel si on regarde a ses pieds
+
 */
 
 import java.awt.Robot;
@@ -24,10 +17,8 @@ float sensi=0.01;
 
 inputManager im;
 
-boolean once=true;
-
 void setup() {
-  fullScreen(P3D);
+  fullScreen(P3D,2);
   //size(500, 500, P3D);
 
   frameRate(1000);

--- a/minecrap.pde
+++ b/minecrap.pde
@@ -55,6 +55,7 @@ void setup() {
 
 void draw() {
   background(255);
+  cm.renderChunk();
 
   camera(p.x, -p.y-1, p.z, p.x-sin(p.lr)*cos(p.ud), -p.y-1-sin(p.ud), p.z-cos(p.lr)*cos(p.ud), 0, 1, 0);
 


### PR DESCRIPTION
- PShape + multithreading != <3 donc on va les creer dans le thread principal
  - chunk : 
    - rebougé le renderBlocks pour y avoir acces apres sa creation (creation thread secondaire / utilisation thread principal)
    - maintenant on peut faire un appel a PShape.draw juste apres la creation du chunk pour update la geometry/tesselation (mnt que j y pense sa sert a rien vu qu on est dans le meme thread)
    - renommé renderShape en computeFacesToRender pour clarté + renderShape ne demarre plus automatiquement createRenderShape
  - chunkManager : 
    - les chunks sont rendered dans le thread principal
     -> ajout d'une queue pour les chunks a render
     -> ajout de la fonction renderChunk pour render un chunk a chaque frame
    - renommé startChunkRender en startChunkGeneration par soucis de clarté
    - les queue pour la generation/render des chunks stockent maintenant la position de chunkManager au moment de l'ajout pour s'adapter si le joueur bougent alors que tout les chunks ne sont pas encore loadés